### PR TITLE
Add Windows Compability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, Extension
 from torch.utils import cpp_extension
+import platform
 
 setup(
     name="exllama",
@@ -14,7 +15,6 @@ setup(
             "exllama_ext",
             [
                 "exllama_ext/exllama_ext.cpp",
-
                 "exllama_ext/cuda_buffers.cu",
                 "exllama_ext/cuda_func/q4_matrix.cu",
                 "exllama_ext/cuda_func/q4_matmul.cu",
@@ -22,12 +22,11 @@ setup(
                 "exllama_ext/cuda_func/rms_norm.cu",
                 "exllama_ext/cuda_func/rope.cu",
                 "exllama_ext/cuda_func/half_matmul.cu",
-
                 "exllama_ext/cuda_func/q4_mlp.cu",
-
                 "exllama_ext/cpu_func/rep_penalty.cpp",
             ],
             extra_compile_args={"nvcc": ["-O3"]},
+            libraries=["cublas"] if platform.system() == "Windows" else [],
         ),
     ],
     cmdclass={"build_ext": cpp_extension.BuildExtension},


### PR DESCRIPTION
- If system is Windows, add the "cublas" library to compile.

This let Windows build exllama to be used on KoboldAI.

Fixes
```
alf_matmul.obj: error LNK2001: unresolved external symbol cublasHgemm
q4_matmul.obj : error LNK2001: unresolved external symbol cublasHgemm
```

- CUDA [(CUDA Toolkit)](https://developer.nvidia.com/cuda-toolkit-archive) correspondent to the torch version is needed (CUDA 12.1 for cu121, CUDA 11.8 for cu118) 
- Also, it needs Visual Studio Code 2022 [MSVC 2022](https://visualstudio.microsoft.com/downloads/) or [Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with Desktop development with C++ Build Tools option.