### PR TITLE
Remove unhelpful Python version warning message.

### DIFF
--- a/exllama/model.py
+++ b/exllama/model.py
@@ -1,10 +1,3 @@
-import sys
-min_version = (3, 9)
-if sys.version_info < min_version:
-    print("")
-    print(f" ## Warning: this project requires Python {min_version[0]}.{min_version[1]} or higher.")
-    print("")
-
 import torch
 from torch import nn
 import torch.nn.functional as F


### PR DESCRIPTION
Exllama inference works with Python 3.8. Remove this unnecessary warning.